### PR TITLE
feat: 新增自动登录时重新获取IP并覆盖原有配置的功能

### DIFF
--- a/Ui/Settings.py
+++ b/Ui/Settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'Settings.ui'
+# Form implementation generated from reading ui file 'f:\Github\SEIG-Auto-Connect\Ui\Settings.ui'
 #
 # Created by: PyQt5 UI code generator 5.15.11
 #
@@ -239,4 +239,4 @@ class Ui_sac_settings(object):
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_4), _translate("sac_settings", "关于"))
         self.pushButton.setText(_translate("sac_settings", "保存"))
         self.pushButton_2.setText(_translate("sac_settings", "取消"))
-import res.res_rc #新生成的ui代码把这里改成了 'import res_rc'，但是IDE标红了，所以改回原来的
+import res.res_rc

--- a/Ui/Settings.py
+++ b/Ui/Settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'Settings.ui'
+# Form implementation generated from reading ui file 'f:\Github\SEIG-Auto-Connect\Ui\Settings.ui'
 #
 # Created by: PyQt5 UI code generator 5.15.11
 #
@@ -214,7 +214,7 @@ class Ui_sac_settings(object):
         sac_settings.setWindowTitle(_translate("sac_settings", "Form"))
         self.pushButton_3.setText(_translate("sac_settings", "自动获取"))
         self.checkBox_autoCheckIP.setToolTip(_translate("sac_settings", "自动登录开启时，每次都重新获取一次登录信息。这可能适用于在学校不同地方接入网络时IP变化的问题。"))
-        self.checkBox_autoCheckIP.setText(_translate("sac_settings", "每次自动登录都获取一次"))
+        self.checkBox_autoCheckIP.setText(_translate("sac_settings", "自动登录时触发获取"))
         self.label.setText(_translate("sac_settings", "登录URL"))
         self.label_2.setText(_translate("sac_settings", "登录服务器IP"))
         self.label_3.setText(_translate("sac_settings", "本地IP"))
@@ -239,4 +239,4 @@ class Ui_sac_settings(object):
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_4), _translate("sac_settings", "关于"))
         self.pushButton.setText(_translate("sac_settings", "保存"))
         self.pushButton_2.setText(_translate("sac_settings", "取消"))
-import res.res_rc #新生成的ui代码把这里改成了 'import res_rc'，但是IDE标红了，所以改回原来的
+import res.res_rc

--- a/Ui/Settings.py
+++ b/Ui/Settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'f:\Github\SEIG-Auto-Connect\Ui\Settings.ui'
+# Form implementation generated from reading ui file 'Settings.ui'
 #
 # Created by: PyQt5 UI code generator 5.15.11
 #
@@ -46,6 +46,9 @@ class Ui_sac_settings(object):
         self.pushButton_3.setMinimumSize(QtCore.QSize(0, 33))
         self.pushButton_3.setObjectName("pushButton_3")
         self.verticalLayout.addWidget(self.pushButton_3)
+        self.checkBox_autoCheckIP = QtWidgets.QCheckBox(self.frame)
+        self.checkBox_autoCheckIP.setObjectName("checkBox_autoCheckIP")
+        self.verticalLayout.addWidget(self.checkBox_autoCheckIP)
         self.label = QtWidgets.QLabel(self.frame)
         self.label.setObjectName("label")
         self.verticalLayout.addWidget(self.label)
@@ -210,6 +213,8 @@ class Ui_sac_settings(object):
         _translate = QtCore.QCoreApplication.translate
         sac_settings.setWindowTitle(_translate("sac_settings", "Form"))
         self.pushButton_3.setText(_translate("sac_settings", "自动获取"))
+        self.checkBox_autoCheckIP.setToolTip(_translate("sac_settings", "自动登录开启时，每次都重新获取一次登录信息。这可能适用于在学校不同地方接入网络时IP变化的问题。"))
+        self.checkBox_autoCheckIP.setText(_translate("sac_settings", "每次自动登录都获取一次"))
         self.label.setText(_translate("sac_settings", "登录URL"))
         self.label_2.setText(_translate("sac_settings", "登录服务器IP"))
         self.label_3.setText(_translate("sac_settings", "本地IP"))
@@ -234,4 +239,4 @@ class Ui_sac_settings(object):
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_4), _translate("sac_settings", "关于"))
         self.pushButton.setText(_translate("sac_settings", "保存"))
         self.pushButton_2.setText(_translate("sac_settings", "取消"))
-import res.res_rc
+import res.res_rc #新生成的ui代码把这里改成了 'import res_rc'，但是IDE标红了，所以改回原来的

--- a/Ui/Settings.ui
+++ b/Ui/Settings.ui
@@ -79,6 +79,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="checkBox_autoCheckIP">
+            <property name="toolTip">
+             <string>自动登录开启时，每次都重新获取一次登录信息。这可能适用于在学校不同地方接入网络时IP变化的问题。</string>
+            </property>
+            <property name="text">
+             <string>每次自动登录都获取一次</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QLabel" name="label">
             <property name="text">
              <string>登录URL</string>

--- a/Ui/Settings.ui
+++ b/Ui/Settings.ui
@@ -84,7 +84,7 @@
              <string>自动登录开启时，每次都重新获取一次登录信息。这可能适用于在学校不同地方接入网络时IP变化的问题。</string>
             </property>
             <property name="text">
-             <string>每次自动登录都获取一次</string>
+             <string>自动登录时触发获取</string>
             </property>
            </widget>
           </item>

--- a/main.py
+++ b/main.py
@@ -110,7 +110,11 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             view.customContextMenuRequested.connect(self.show_combo_menu)
 
             # 启动后运行
-            self.try_auto_connect()
+            if state.auto_update_userip == "1":
+                self.auto_connect_reload_ip()
+            else:
+                self.try_auto_connect()
+                
             self.start_easytier()
 
         except Exception as e:
@@ -364,18 +368,15 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         else:
             self.update_list(f"创建开机自启失败：{r.stderr or r.stdout}\n尝试以管理员权限运行软件")
 
-    def update_login_config(self):
-        self.update_list("正在重新获取登录IP......")
-        self.settings_window.get_default()
-        self.update_config('esurfingurl', str(state.esurfingurl))
-        self.update_config('wlanuserip', str(state.wlanuserip))
-        self.update_config('wlanacip', str(state.wlanacip))
+    def auto_connect_reload_ip(self):
+        if state.auto_update_userip == "1":
+            self.update_list("正在重新获取登录IP......")
+            self.settings_window.get_default(mode="nomsgbox_autologin")
+            self.settings_window.save_config()
 
     def try_auto_connect(self):
 
         self.read_config()
-        if state.auto_update_userip == "1":
-            self.update_login_config()
 
         if state.auto_connect == "1":
             self.update_list("正在尝试自动连接...")

--- a/main.py
+++ b/main.py
@@ -372,7 +372,6 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         if state.auto_update_userip == "1":
             self.update_list("正在重新获取登录IP......")
             self.settings_window.get_default(mode="nomsgbox_autologin")
-            self.settings_window.save_config()
 
     def try_auto_connect(self):
 

--- a/main.py
+++ b/main.py
@@ -366,7 +366,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
     def try_auto_connect(self):
 
         # 直接自动获取覆盖登录IP信息，设为1时生效。
-        if state.auto_update_userip == "1":
+        if state.auto_update_userip == "1" and state.auto_connect == "1":
             self.update_list("正在重新获取登录IP......")
             settingsWindow.get_default(self.settings_window)
             update_entry('esurfingurl', str(state.esurfingurl), state.config_path)

--- a/main.py
+++ b/main.py
@@ -368,7 +368,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         self.read_config()
 
         # 直接自动获取覆盖登录IP信息，设为1时生效。
-        if state.auto_update_userip == "1":
+        if state.auto_update_userip == 1:
             settingsWindow.get_default(self.settings_window)
         if state.auto_connect == "1":
             self.update_list("正在尝试自动连接...")

--- a/main.py
+++ b/main.py
@@ -368,7 +368,8 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         self.read_config()
 
         # 直接自动获取覆盖登录IP信息，设为1时生效。
-        if state.auto_update_userip == 1:
+        if state.auto_update_userip == "1":
+            self.update_list("正在重新获取登录IP......")
             settingsWindow.get_default(self.settings_window)
         if state.auto_connect == "1":
             self.update_list("正在尝试自动连接...")
@@ -454,6 +455,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             ('login_mode', 0, int),
             ('enable_watch_dog', "1", str),
             ('auto_share', "0", str),
+            ('auto_update_userip', "0", str),
             # Easytier
             ('et_secret_key', "Hello_InterKnot", str),
             ('et_enable_ipv6', 0, int),

--- a/main.py
+++ b/main.py
@@ -73,6 +73,46 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             self.read_config()
             self.get_password()
             self.add_account_to_combox()
+
+            # 初始化Setting
+            self.settings_window = settingsWindow(self)
+
+            # 绑定按钮功能
+            self.pushButton.clicked.connect(self.login)
+            self.pushButton_2.clicked.connect(self.logout)
+            self.checkBox.clicked.connect(lambda checked: (self.update_config(
+                "save_pwd", "1" if checked else "0") or self.init_save_password(checked)))
+
+            self.checkBox_2.clicked.connect(lambda: self.update_config(
+                "auto_connect", 1 if self.checkBox_2.isChecked() else 0) or (
+                    self.checkBox.setChecked(True) if self.checkBox_2.isChecked() else None) or (
+                        self.add_to_startup() if self.checkBox_2.isChecked() else self.add_to_startup(1)) or (self.update_config("save_pwd", 1))
+            )
+            self.checkBox_auto_share.clicked.connect(
+                lambda checked: self.enable_auto_share(checked))
+
+            self.checkBox_t.clicked.connect(lambda: self.change_login_mode(
+                1 if self.checkBox_t.isChecked() else 0))
+
+            self.checkBox_dog.clicked.connect(lambda: self.update_config(
+                "enable_watch_dog", 1 if self.checkBox_dog.isChecked() else 0) or (self.update_list("看门狗将在下次登录时开启，持续监测网络状态，根据网卡状态智能重连") if self.checkBox_dog.isChecked() else self.update_list("看门狗已禁用")))
+
+            self.pushButton_3.clicked.connect(
+                lambda: web.open_new("https://cmxz.top"))
+            self.run_settings_action.triggered.connect(self.run_settings)
+            self.pushButton_4.clicked.connect(self.settings_window.mulit_login_now)
+            self.pushButton_enable_share.clicked.connect(
+                lambda: self.start_easytier(True))
+
+            self.comboBox_username.currentTextChanged.connect(self.on_user_changed)
+            view = self.comboBox_username.view()
+            view.setContextMenuPolicy(Qt.CustomContextMenu)
+            view.customContextMenuRequested.connect(self.show_combo_menu)
+
+            # 启动后运行
+            self.try_auto_connect()
+            self.start_easytier()
+
         except Exception as e:
             trace = traceback.format_exc()
             detail = (
@@ -82,45 +122,6 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             self.write_to_log(detail)
             self.show_message(detail, "错误")
             sys.exit()
-
-        # 初始化Setting
-        self.settings_window = settingsWindow(self)
-
-        # 绑定按钮功能
-        self.pushButton.clicked.connect(self.login)
-        self.pushButton_2.clicked.connect(self.logout)
-        self.checkBox.clicked.connect(lambda checked: (self.update_config(
-            "save_pwd", "1" if checked else "0") or self.init_save_password(checked)))
-
-        self.checkBox_2.clicked.connect(lambda: self.update_config(
-            "auto_connect", 1 if self.checkBox_2.isChecked() else 0) or (
-                self.checkBox.setChecked(True) if self.checkBox_2.isChecked() else None) or (
-                    self.add_to_startup() if self.checkBox_2.isChecked() else self.add_to_startup(1)) or (self.update_config("save_pwd", 1))
-        )
-        self.checkBox_auto_share.clicked.connect(
-            lambda checked: self.enable_auto_share(checked))
-
-        self.checkBox_t.clicked.connect(lambda: self.change_login_mode(
-            1 if self.checkBox_t.isChecked() else 0))
-
-        self.checkBox_dog.clicked.connect(lambda: self.update_config(
-            "enable_watch_dog", 1 if self.checkBox_dog.isChecked() else 0) or (self.update_list("看门狗将在下次登录时开启，持续监测网络状态，根据网卡状态智能重连") if self.checkBox_dog.isChecked() else self.update_list("看门狗已禁用")))
-
-        self.pushButton_3.clicked.connect(
-            lambda: web.open_new("https://cmxz.top"))
-        self.run_settings_action.triggered.connect(self.run_settings)
-        self.pushButton_4.clicked.connect(self.settings_window.mulit_login_now)
-        self.pushButton_enable_share.clicked.connect(
-            lambda: self.start_easytier(True))
-
-        self.comboBox_username.currentTextChanged.connect(self.on_user_changed)
-        view = self.comboBox_username.view()
-        view.setContextMenuPolicy(Qt.CustomContextMenu)
-        view.customContextMenuRequested.connect(self.show_combo_menu)
-
-        # 启动后运行
-        self.try_auto_connect()
-        self.start_easytier()
 
     def init_log(self):
         os.makedirs(state.config_dir, exist_ok=True)
@@ -363,17 +364,18 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         else:
             self.update_list(f"创建开机自启失败：{r.stderr or r.stdout}\n尝试以管理员权限运行软件")
 
+    def update_login_config(self):
+        self.update_list("正在重新获取登录IP......")
+        self.settings_window.get_default()
+        self.update_config('esurfingurl', str(state.esurfingurl))
+        self.update_config('wlanuserip', str(state.wlanuserip))
+        self.update_config('wlanacip', str(state.wlanacip))
+
     def try_auto_connect(self):
 
-        # 直接自动获取覆盖登录IP信息，设为1时生效。
-        if state.auto_update_userip == "1":
-            self.update_list("正在重新获取登录IP......")
-            settingsWindow.get_default(self.settings_window)
-            update_entry('esurfingurl', str(state.esurfingurl), state.config_path)
-            update_entry('wlanuserip', str(state.wlanuserip) , state.config_path)
-            update_entry('wlanacip', str(state.wlanacip), state.config_path)
-
         self.read_config()
+        if state.auto_update_userip == "1":
+            self.update_login_config()
 
         if state.auto_connect == "1":
             self.update_list("正在尝试自动连接...")

--- a/main.py
+++ b/main.py
@@ -73,7 +73,6 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             self.read_config()
             self.get_password()
             self.add_account_to_combox()
-            self.try_auto_connect()
         except Exception as e:
             trace = traceback.format_exc()
             detail = (
@@ -120,6 +119,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         view.customContextMenuRequested.connect(self.show_combo_menu)
 
         # 启动后运行
+        self.try_auto_connect()
         self.start_easytier()
 
     def init_log(self):
@@ -366,6 +366,10 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
     def try_auto_connect(self):
 
         self.read_config()
+
+        # 直接自动获取覆盖登录IP信息，设为1时生效。
+        if state.auto_update_userip == "1":
+            settingsWindow.get_default(self.settings_window)
         if state.auto_connect == "1":
             self.update_list("正在尝试自动连接...")
             self.auto_connect_flag_for_pwd = True

--- a/main.py
+++ b/main.py
@@ -365,12 +365,16 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
     def try_auto_connect(self):
 
-        self.read_config()
-
         # 直接自动获取覆盖登录IP信息，设为1时生效。
         if state.auto_update_userip == "1":
             self.update_list("正在重新获取登录IP......")
             settingsWindow.get_default(self.settings_window)
+            update_entry('esurfingurl', str(state.esurfingurl), state.config_path)
+            update_entry('wlanuserip', str(state.wlanuserip) , state.config_path)
+            update_entry('wlanacip', str(state.wlanacip), state.config_path)
+
+        self.read_config()
+
         if state.auto_connect == "1":
             self.update_list("正在尝试自动连接...")
             self.auto_connect_flag_for_pwd = True

--- a/main.py
+++ b/main.py
@@ -369,7 +369,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             self.update_list(f"创建开机自启失败：{r.stderr or r.stdout}\n尝试以管理员权限运行软件")
 
     def auto_connect_reload_ip(self):
-        if state.auto_update_userip == "1":
+        if state.auto_connect == "1":
             self.update_list("正在重新获取登录IP......")
             self.settings_window.get_default(mode="nomsgbox_autologin")
 

--- a/modules/Easytier.py
+++ b/modules/Easytier.py
@@ -221,7 +221,7 @@ dev_name = "InterKnot"
 
                 elif self.mode == "server":
                     self.signals.print_text.emit(
-                        f"ET: {line.split('remote_addr: Some(Url { url: "wg://')[1].split(':')[0]} 已断开连接！")
+                        f"""ET: {line.split('remote_addr: Some(Url { url: "wg://')[1].split(':')[0]} 已断开连接！""")
 
             # 检测错误
             if any(k in lower_line for k in ("panic", "stopping", "error")) and output:

--- a/modules/Get_Userip_Thread.py
+++ b/modules/Get_Userip_Thread.py
@@ -23,14 +23,8 @@ class Get_Userip_Thread(QRunnable):
                 "wlanacip=(.+?)&", response.url).group(1)
             state.wlanuserip = re.search(
                 "wlanuserip=(.+)", response.url).group(1)
-            self.signals.print_text.emit("成功获取参数")
             self.signals.finished.emit()
 
         except Exception as e:
-            if "'NoneType' object has no attribute 'group'" in str(e):
-                self.signals.print_text.emit(f"没有从重定向的链接中获取到参数，请检查网线连接，或者是否已经能够上网了？{e}")
-
-            else:
-                self.signals.print_text.emit(f"自动获取失败，请检查以下项目\n\n①确保没有连接手机热点\n②已经登录过校园网需先断开\n③检查是否开启网络代理\n④检查网线连接\n{e}")
-            
+            self.signals.print_text.emit(f"自动获取失败，请检查以下项目\n\n①确保没有连接手机热点\n②已经登录过校园网需先断开\n③检查是否开启网络代理\n④检查网线连接\n{e}")
             self.signals.enable_buttoms.emit(2)

--- a/modules/Get_Userip_Thread.py
+++ b/modules/Get_Userip_Thread.py
@@ -1,0 +1,36 @@
+import requests
+import re
+from PyQt5.QtCore import QRunnable
+
+from modules.State import global_state
+from modules.Working_signals import WorkerSignals
+
+state = global_state()
+
+
+class Get_Userip_Thread(QRunnable):
+    def __init__(self):
+        super().__init__()
+        self.signals = WorkerSignals()
+
+    def run(self):
+        try:
+            response = requests.get(
+                url="http://189.cn/", timeout=2, proxies={"http": None, "https": None})
+            state.esurfingurl = re.search(
+                "http://(.+?)/", response.url).group(1)
+            state.wlanacip = re.search(
+                "wlanacip=(.+?)&", response.url).group(1)
+            state.wlanuserip = re.search(
+                "wlanuserip=(.+)", response.url).group(1)
+            self.signals.print_text.emit("成功获取参数")
+            self.signals.finished.emit()
+
+        except Exception as e:
+            if "'NoneType' object has no attribute 'group'" in str(e):
+                self.signals.print_text.emit(f"没有从重定向的链接中获取到参数，请检查网线连接，或者是否已经能够上网了？{e}")
+
+            else:
+                self.signals.print_text.emit(f"自动获取失败，请检查以下项目\n\n①确保没有连接手机热点\n②已经登录过校园网需先断开\n③检查是否开启网络代理\n④检查网线连接\n{e}")
+            
+            self.signals.enable_buttoms.emit(2)

--- a/modules/Setting.py
+++ b/modules/Setting.py
@@ -359,6 +359,7 @@ class settingsWindow(QtWidgets.QMainWindow, Ui_sac_settings):  # 设置窗口
                 self.pushButton_3.setText("自动获取")
 
             if mode == "nomsgbox_autologin":
+                self.save_config()
                 self.Main_window.try_auto_connect()
 
         self.pushButton_3.setEnabled(False)

--- a/modules/Setting.py
+++ b/modules/Setting.py
@@ -318,6 +318,7 @@ class settingsWindow(QtWidgets.QMainWindow, Ui_sac_settings):  # 设置窗口
         self.lineEdit_3.setText(state.wlanuserip)
         # 获取本地网卡IP
         local_ip = self.get_lan_ip()
+        self.comboBox.clear()
         self.comboBox.addItem(local_ip if isinstance(
             local_ip, str) else local_ip[0])
         self.comboBox.addItem("IP仅供参考，分享请使用物理IP")

--- a/modules/Setting.py
+++ b/modules/Setting.py
@@ -9,6 +9,7 @@ from PyQt5.QtCore import QThreadPool, pyqtSignal, QRunnable, QObject, QTimer, QM
 from Ui.Main_UI import Ui_MainWindow  # 导入ui文件
 from Ui.Settings import Ui_sac_settings
 from modules.SecurityManager import *
+from modules.Get_Userip_Thread import Get_Userip_Thread
 
 from modules.State import global_state
 
@@ -341,29 +342,53 @@ class settingsWindow(QtWidgets.QMainWindow, Ui_sac_settings):  # 设置窗口
             "auto_update_userip", 1 if self.checkBox_autoCheckIP.isChecked() else 0)
         self.close()
 
-    def get_default(self):
-        try:
-            response = requests.get(url="http://189.cn/", timeout=2, proxies={"http": None, "https": None})
-            state.esurfingurl = re.search(
-                "http://(.+?)/", response.url).group(1)
-            state.wlanacip = re.search(
-                "wlanacip=(.+?)&", response.url).group(1)
-            state.wlanuserip = re.search(
-                "wlanuserip=(.+)", response.url).group(1)
-            self.get_config_value()
-            try:
-                self.pushButton.setEnabled(True)
+    def get_default(self, mode=""):
+        if isinstance(mode, bool):
+            mode = ""
+        def get_ip_status(result=1):
+            if result == 1:
                 self.Main_window.update_list("成功获取参数")
-            except:
-                pass
-        except Exception as e:
-            if "'NoneType' object has no attribute 'group'" in str(e):
-                self.Main_window.update_list(
-                    f"没有从重定向的链接中获取到参数，请检查网线连接，或者是否已经能够上网了？{e}")
+                self.pushButton_3.setEnabled(True)
+                self.get_config_value()
+            
             else:
-                self.Main_window.update_list(f"自动获取失败，请检查以下项目\n\n①确保没有连接手机热点\n②已经登录过校园网需先断开\n③检查是否开启网络代理\n④检查网线连接\n{e}")
-                self.Main_window.show_message(message="自动获取失败，请检查以下项目\n\n①确保没有连接手机热点\n②已经登录过校园网需先断开\n③检查是否开启网络代理\n④检查网线连接", title="错误")
-            self.pushButton.setEnabled(False)
+                self.pushButton_3.setEnabled(True)
+                if "nomsgbox" not in mode:
+                    self.Main_window.show_message(message="自动获取失败，请检查以下项目\n\n①确保没有连接手机热点\n②已经登录过校园网需先断开\n③检查是否开启网络代理\n④检查网线连接", title="错误")
+                self.pushButton_3.setText("自动获取")
+
+            if mode == "nomsgbox_autologin":
+                self.Main_window.try_auto_connect()
+
+        self.pushButton_3.setEnabled(False)
+        self.pushButton_3.setText("正在获取中...")
+        get_userip_thread = Get_Userip_Thread()
+        get_userip_thread.signals.enable_buttoms.connect(get_ip_status)
+        get_userip_thread.signals.finished.connect(get_ip_status)
+        get_userip_thread.signals.print_text.connect(self.Main_window.update_list)
+        state.threadpool.start(get_userip_thread)
+        # try:
+        #     response = requests.get(url="http://189.cn/", timeout=2, proxies={"http": None, "https": None})
+        #     state.esurfingurl = re.search(
+        #         "http://(.+?)/", response.url).group(1)
+        #     state.wlanacip = re.search(
+        #         "wlanacip=(.+?)&", response.url).group(1)
+        #     state.wlanuserip = re.search(
+        #         "wlanuserip=(.+)", response.url).group(1)
+        #     self.get_config_value()
+        #     try:
+        #         self.pushButton.setEnabled(True)
+        #         self.Main_window.update_list("成功获取参数")
+        #     except:
+        #         pass
+        # except Exception as e:
+        #     if "'NoneType' object has no attribute 'group'" in str(e):
+        #         self.Main_window.update_list(
+        #             f"没有从重定向的链接中获取到参数，请检查网线连接，或者是否已经能够上网了？{e}")
+        #     else:
+        #         self.Main_window.update_list(f"自动获取失败，请检查以下项目\n\n①确保没有连接手机热点\n②已经登录过校园网需先断开\n③检查是否开启网络代理\n④检查网线连接\n{e}")
+        #         self.Main_window.show_message(message="自动获取失败，请检查以下项目\n\n①确保没有连接手机热点\n②已经登录过校园网需先断开\n③检查是否开启网络代理\n④检查网线连接", title="错误")
+        #     self.pushButton.setEnabled(False)
 
     def run_settings_window(self):
         self.showNormal()  # 恢复窗口（如果被最小化）

--- a/modules/Setting.py
+++ b/modules/Setting.py
@@ -350,6 +350,7 @@ class settingsWindow(QtWidgets.QMainWindow, Ui_sac_settings):  # 设置窗口
                 self.Main_window.update_list("成功获取参数")
                 self.pushButton_3.setEnabled(True)
                 self.get_config_value()
+                self.pushButton_3.setText("自动获取")
             
             else:
                 self.pushButton_3.setEnabled(True)

--- a/modules/Setting.py
+++ b/modules/Setting.py
@@ -45,8 +45,7 @@ class settingsWindow(QtWidgets.QMainWindow, Ui_sac_settings):  # 设置窗口
         self.pushButton_7.clicked.connect(self.clear_config)
         self.pushButton_8.clicked.connect(
             lambda: os.startfile(state.config_dir))
-        self.checkBox_autoCheckIP.clicked.connect(lambda: self.Main_window.update_config(
-            "auto_update_userip", 1 if self.checkBox_autoCheckIP.isChecked() else 0) or (self.Main_window.update_list("将在下次自动登录时重新获取IP") if self.checkBox_autoCheckIP.isChecked() else self.Main_window.update_list("自动更新登录IP已关闭")))
+        self.checkBox_autoCheckIP.clicked.connect(lambda: self.Main_window.update_list("将在每次自动登录前重新获取IP") if self.checkBox_autoCheckIP.isChecked() else self.Main_window.update_list("自动更新登录IP已关闭"))
 
         self.get_config_value()
 
@@ -327,6 +326,7 @@ class settingsWindow(QtWidgets.QMainWindow, Ui_sac_settings):  # 设置窗口
             f"隧道端口: {state.et_port} | WebUI: {state.et_webui_port}")
         self.checkBox_2.setChecked(True if state.et_enable_ipv6 else False)
         self.checkBox.setChecked(True if state.et_enable_webdl else False)
+        self.checkBox_autoCheckIP.setChecked(True if state.auto_update_userip == "1" else False)
 
     def save_config(self):
         self.Main_window.update_config("esurfingurl", self.lineEdit.text())
@@ -337,6 +337,8 @@ class settingsWindow(QtWidgets.QMainWindow, Ui_sac_settings):  # 设置窗口
             "et_enable_ipv6", 1 if self.checkBox_2.isChecked() else 0)
         self.Main_window.update_config(
             "et_enable_webdl", 1 if self.checkBox.isChecked() else 0)
+        self.Main_window.update_config(
+            "auto_update_userip", 1 if self.checkBox_autoCheckIP.isChecked() else 0)
         self.close()
 
     def get_default(self):

--- a/modules/Setting.py
+++ b/modules/Setting.py
@@ -45,6 +45,8 @@ class settingsWindow(QtWidgets.QMainWindow, Ui_sac_settings):  # 设置窗口
         self.pushButton_7.clicked.connect(self.clear_config)
         self.pushButton_8.clicked.connect(
             lambda: os.startfile(state.config_dir))
+        self.checkBox_autoCheckIP.clicked.connect(lambda: self.Main_window.update_config(
+            "auto_update_userip", 1 if self.checkBox_autoCheckIP.isChecked() else 0) or (self.Main_window.update_list("将在下次自动登录时重新获取IP") if self.checkBox_autoCheckIP.isChecked() else self.Main_window.update_list("自动更新登录IP已关闭")))
 
         self.get_config_value()
 

--- a/modules/Setting.py
+++ b/modules/Setting.py
@@ -327,6 +327,7 @@ class settingsWindow(QtWidgets.QMainWindow, Ui_sac_settings):  # 设置窗口
             f"隧道端口: {state.et_port} | WebUI: {state.et_webui_port}")
         self.checkBox_2.setChecked(True if state.et_enable_ipv6 else False)
         self.checkBox.setChecked(True if state.et_enable_webdl else False)
+        self.checkBox_autoCheckIP.setChecked(True if state.auto_update_userip == "1" else False)
 
     def save_config(self):
         self.Main_window.update_config("esurfingurl", self.lineEdit.text())

--- a/modules/State.py
+++ b/modules/State.py
@@ -16,7 +16,7 @@ class global_state:
             return
         self._initialized = True
 
-        self.version = 1.66
+        self.version = 1.67
 
         # 获取用户 AppData\Roaming 路径
         self.config_path = None

--- a/modules/State.py
+++ b/modules/State.py
@@ -42,6 +42,7 @@ class global_state:
         self.mulit_info = {}
         self.enable_easytier = None
         self.auto_share = False
+        self.auto_update_userip = None # 自动检查用户IP是否变化的开关位
 
         # EasyTier相关配置
         self.et_port = 51145

--- a/modules/Working_signals.py
+++ b/modules/Working_signals.py
@@ -16,3 +16,4 @@ class WorkerSignals(QObject):
     jar_login_success = pyqtSignal()
     login_status = pyqtSignal(object)
     run_settings = pyqtSignal()
+    get_userip_status = pyqtSignal(bool, str)

--- a/modules/Working_signals.py
+++ b/modules/Working_signals.py
@@ -16,4 +16,3 @@ class WorkerSignals(QObject):
     jar_login_success = pyqtSignal()
     login_status = pyqtSignal(object)
     run_settings = pyqtSignal()
-    get_userip_status = pyqtSignal(bool, str)

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -9,6 +9,7 @@ from .Login_Thread import login_Thread
 from .Easytier import easytier_thread
 from .WebUI import WebUIThread, stop_webui_server
 from .SecurityManager import SecurityManager, DatManager
+from .Get_Userip_Thread import Get_Userip_Thread
 
 __all__ = [
     "global_state",
@@ -24,5 +25,6 @@ __all__ = [
     "WebUIThread",
     "stop_webui_server",
     "SecurityManager",
-    "DatManager"
+    "DatManager",
+    "Get_Userip_Thread"
 ]


### PR DESCRIPTION
针对跑到图书馆连WiFi会变IP的痛点，增加了这个功能。但是在设置窗口里新增的Checkbox似乎有点小bug嗯
开启这个功能后自动登录会重新获取三个地址并且直接覆盖原有的配置
另外Easytier模块在python 3.10.9运行时会爆字符串闭合的问题，详情在提交里查看